### PR TITLE
Remove extraneous } from hpc-cluster.json

### DIFF
--- a/aws-cloudformation/aws-tools/templates/all-in-one/hpc-cluster.json
+++ b/aws-cloudformation/aws-tools/templates/all-in-one/hpc-cluster.json
@@ -101,7 +101,6 @@
                         }
                     }
                 ]
-            }
             },
             "Condition": "CreateNetwork"
         },


### PR DESCRIPTION
This is now valid JSON.  I believe it is also a valid cloudformation template, but you would be wise to double check that :-)
