### PR TITLE
Base storage account name on resource group name to avoid clashing when

### DIFF
--- a/how-to/deployment/azure/hpc/azure-resource-manager/flight.json
+++ b/how-to/deployment/azure/hpc/azure-resource-manager/flight.json
@@ -72,7 +72,7 @@
 		},
 		"azureConfig": {
 			"imageSubscription": "[concat('/subscriptions/', 'd1e964ef-15c7-4b27-8113-e725167cee83', '/resourceGroups/', variables('alcesFlightConfig').resourceGroup, '/providers/Microsoft.Compute/', variables('alcesFlightConfig').storageContainer ,'/alces-flight-',variables('alcesFlightConfig').appliance, '-', variables('alcesFlightConfig').version)]",
-			"storageAccountName": "[concat(uniqueString(parameters('clusterName'), 'storage'))]",
+			"storageAccountName": "[resourceGroup().name]",
 			"storageAccountDiskStorageType": "Standard_LRS",
 			"storageAccountDiskStorageTier": "Standard"
 		},


### PR DESCRIPTION
the same cluster name is used